### PR TITLE
Reworking encoding name parsing.

### DIFF
--- a/lib.ps1
+++ b/lib.ps1
@@ -57,45 +57,49 @@ function resolveEncodings {
         # If $PSDefaultParameterValues contains a default for the Encoding parameter, it may contain one of these, and these don't neatly map to WebName.
         # @see https://stackoverflow.com/a/40098904/17152
         # @see https://docs.microsoft.com/en-us/dotnet/api/microsoft.powershell.commands.filesystemcmdletproviderencoding
-        switch ($_ -as [Microsoft.PowerShell.Commands.FileSystemCmdletProviderEncoding]) {
-            Unknown {
+        switch ($_) {
+            'Unknown' {
                 # Unknown: should not map
                 throw "The encoding '$_' is not supported."
             }
-            String {
+            'String' {
                 # 'String' is described by Microsoft as "Unicode encoding", which is how they describe 'Unicode'.
                 return [System.Text.Encoding]::Unicode
             }
-            Unicode {
+            'Unicode' {
                 return [System.Text.Encoding]::Unicode
             }
-            Byte {
+            'Byte' {
                 # Byte: Seems to be a special value to return a byte array instead of a string.  Not sure the right course of action here.
                 throw "The encoding '$_' is not supported."
             }
-            BigEndianUnicode {
+            'BigEndianUnicode' {
                 return [System.Text.Encoding]::BigEndianUnicode
             }
-            UTF8 {
+            'UTF8' {
                 return [System.Text.Encoding]::UTF8
             }
-            UTF7 {
+            'UTF7' {
                 return [System.Text.Encoding]::UTF7
             }
-            UTF32 {
+            'UTF32' {
                 return [System.Text.Encoding]::UTF32
             }
-            Ascii {
+            'UTF16' {
+                # NOTE: While "UTF16" isn't actually in the FileSystemCmdletProviderEncoding enum, it *seems* like it should work, so it is also included here.
+                return [System.Text.Encoding]::Unicode
+            }
+            'Ascii' {
                 return [System.Text.Encoding]::Ascii
             }
-            Default {
+            'Default' {
                 return [System.Text.Encoding]::Default
             }
-            Oem {
+            'Oem' {
                 # @see https://stackoverflow.com/a/14583739/17152
                 return [System.Text.Encoding]::GetEncoding($Host.CurrentCulture.TextInfo.OEMCodePage)
             }
-            BigEndianUTF32 {
+            'BigEndianUTF32' {
                 return $allEncodingMap['UTF32-BE']
             }
         }

--- a/lib.ps1
+++ b/lib.ps1
@@ -111,7 +111,7 @@ function resolveEncodings {
         }
 
         # No such luck
-        Write-Error "The encodingxx '$name' does not match any available encoding"
+        Write-Error "The encoding '$name' does not match any available encoding"
 
     } | Select-Object -Unique
 }

--- a/lib.ps1
+++ b/lib.ps1
@@ -35,6 +35,82 @@ if ($missingFiles.Length -ne 0) {
 
 # all encodings supported by the running .NET framework
 $allEncodings = [System.Text.Encoding]::GetEncodings().GetEncoding()
+$allEncodingMap = @{};
+$allEncodings | ForEach-Object { $allEncodingMap[$_.WebName] = $_ }
+
+function resolveEncodings {
+    [CmdletBinding()]
+    [OutputType([System.Text.Encoding[]])]
+    param
+    (
+        [ValidateNotNullOrEmpty()]
+        [string[]] $Encoding
+    )
+
+    $Encoding | ForEach-Object {
+        # Do a direct name lookup first
+        if ($result = $allEncodingMap[$_]) {
+            return $result
+        }
+
+        # Try parsing as the FileSystemCmdletProviderEncoding enum.
+        # If $PSDefaultParameterValues contains a default for the Encoding parameter, it may contain one of these, and these don't neatly map to WebName.
+        # @see https://stackoverflow.com/a/40098904/17152
+        # @see https://docs.microsoft.com/en-us/dotnet/api/microsoft.powershell.commands.filesystemcmdletproviderencoding
+        switch ($_ -as [Microsoft.PowerShell.Commands.FileSystemCmdletProviderEncoding]) {
+            Unknown {
+                # Unknown: should not map
+                throw "The encoding '$_' is not supported."
+            }
+            String {
+                # 'String' is described by Microsoft as "Unicode encoding", which is how they describe 'Unicode'.
+                return [System.Text.Encoding]::Unicode
+            }
+            Unicode {
+                return [System.Text.Encoding]::Unicode
+            }
+            Byte {
+                # Byte: Seems to be a special value to return a byte array instead of a string.  Not sure the right course of action here.
+                throw "The encoding '$_' is not supported."
+            }
+            BigEndianUnicode {
+                return [System.Text.Encoding]::BigEndianUnicode
+            }
+            UTF8 {
+                return [System.Text.Encoding]::UTF8
+            }
+            UTF7 {
+                return [System.Text.Encoding]::UTF7
+            }
+            UTF32 {
+                return [System.Text.Encoding]::UTF32
+            }
+            Ascii {
+                return [System.Text.Encoding]::Ascii
+            }
+            Default {
+                return [System.Text.Encoding]::Default
+            }
+            Oem {
+                # @see https://stackoverflow.com/a/14583739/17152
+                return [System.Text.Encoding]::GetEncoding($Host.CurrentCulture.TextInfo.OEMCodePage)
+            }
+            BigEndianUTF32 {
+                return $allEncodingMap['UTF32-BE']
+            }
+        }
+
+        # Search by pattern (case-insensitive)
+        $name = $_ # because $_ will be overwritten
+        if ($result = $allEncodingMap.Keys | Where-Object { $_ -ilike $name } | Select-Object -Unique) {
+            return $allEncodingMap[$result]
+        }
+
+        # No such luck
+        Write-Error "The encodingxx '$name' does not match any available encoding"
+
+    } | Select-Object -Unique
+}
 
 # rewrite format.ps1xml to dispaly different encodings by default
 function updateFormatting($displayEncodings) {

--- a/unishell.psm1
+++ b/unishell.psm1
@@ -164,7 +164,7 @@ function Get-UniCodepoint {
         loadStub
         $changedFormatting = $false
         if ($encoding) {
-            $displayEncodings = resolveEncodings $encoding -ErrorAction Stop
+            $displayEncodings = resolveEncodings $encoding -ErrorAction Stop | ForEach-Object WebName
             updateFormatting $displayEncodings
             $changedFormatting = $true
         }
@@ -316,7 +316,8 @@ Sweet
 
 .EXAMPLE
 # combine codepoints to form a string
-0x6d,0x65,0x68,0x20,0x1f937 | Get-UniString
+Get-UniString -Codepoint 0x6d,0x65,0x68,0x20,0x1f937
+0x6d,0x65,0x68,0x20,0x1f937 | Get-UniString -Codepoint {$_}
 
 meh 🤷
 


### PR DESCRIPTION
I have the default PowerShell encoding on my workstation set to "UTF8", which was being reported as an error by the `Get-UniCodepoint` command.

I reworked how encoding name parsing is done in order to accomodate those values.  It now supports:
- All `Encoding.WebName` (as before)
- `[FileSystemCmdletProviderEncoding]` enum values (except for `Byte` and `Unknown`).
- A wildcard search is always performed if the first two are not hit, but in practice this means there won't be any matches unless you explicitly use a wildcard.

Please do not hesitate to contact me if you need further information, or if I need to apply any additional fixes before you can accept this PR.

Thanks,
\# Chris
